### PR TITLE
Messagepassing automatic differentiation

### DIFF
--- a/src/GeometricFlux.jl
+++ b/src/GeometricFlux.jl
@@ -3,7 +3,7 @@ module GeometricFlux
 using Statistics: mean
 using StaticArrays: StaticArray
 using SparseArrays: SparseMatrixCSC
-using LinearAlgebra: I, issymmetric, diagm, eigmax, norm, Adjoint
+using LinearAlgebra: I, issymmetric, diagm, eigmax, norm, Adjoint, Diagonal
 
 using Requires
 using DataStructures: DefaultDict
@@ -11,6 +11,7 @@ using Flux
 using Flux: glorot_uniform, leakyrelu, GRUCell
 using Flux: @functor
 using LightGraphs
+using Zygote
 using ZygoteRules
 using FillArrays: Fill
 

--- a/src/layers/meta.jl
+++ b/src/layers/meta.jl
@@ -34,9 +34,7 @@ function propagate(meta::T; adjl=adjlist(meta), kwargs...) where {T<:Meta}
     newE = update_edge(meta; gi=gi, kwargs...)
 
     if haskey(kwargs, :naggr)
-        Zygote.ignore() do
-            cluster = generate_cluster(newE, gi)
-        end
+        cluster = generate_cluster(newE, gi)
         Ē = aggregate_neighbors(meta, kwargs[:naggr]; E=newE, cluster=cluster)
         kwargs = (kwargs..., Ē=Ē)
     end
@@ -57,7 +55,7 @@ function propagate(meta::T; adjl=adjlist(meta), kwargs...) where {T<:Meta}
     (newE, newV, new_u)
 end
 
-function generate_cluster(M::AbstractArray{T,N}, gi::GraphInfo) where {T,N}
+Zygote.@nograd function generate_cluster(M::AbstractArray{T,N}, gi::GraphInfo) where {T,N}
     cluster = similar(M, Int, gi.E)
     @inbounds for i = 1:gi.V
         j = gi.edge_idx[i]

--- a/src/layers/meta.jl
+++ b/src/layers/meta.jl
@@ -34,7 +34,10 @@ function propagate(meta::T; adjl=adjlist(meta), kwargs...) where {T<:Meta}
     newE = update_edge(meta; gi=gi, kwargs...)
 
     if haskey(kwargs, :naggr)
-        Ē = aggregate_neighbors(meta, kwargs[:naggr]; E=newE, cluster=generate_cluster(newE, gi))
+        Zygote.ignore() do
+            cluster = generate_cluster(newE, gi)
+        end
+        Ē = aggregate_neighbors(meta, kwargs[:naggr]; E=newE, cluster=cluster)
         kwargs = (kwargs..., Ē=Ē)
     end
 

--- a/src/layers/msgpass.jl
+++ b/src/layers/msgpass.jl
@@ -35,6 +35,7 @@ update_vertex(m::T; kwargs...) where {T<:MessagePassing} = update(m; kwargs...)
 aggregate_neighbors(m::T, aggr::Symbol; kwargs...) where {T<:MessagePassing} =
     pool(aggr, kwargs[:cluster], kwargs[:M])
 
+# TO DELETE: This is just to make Zygote print better error messages
 aggregate_neighbors(m::T, aggr::Symbol, M, cluster; kwargs...) where {T<:MessagePassing} =
     pool(aggr, cluster, M)
 

--- a/src/layers/msgpass.jl
+++ b/src/layers/msgpass.jl
@@ -34,6 +34,9 @@ update_vertex(m::T; kwargs...) where {T<:MessagePassing} = update(m; kwargs...)
 aggregate_neighbors(m::T, aggr::Symbol; kwargs...) where {T<:MessagePassing} =
     pool(aggr, kwargs[:cluster], kwargs[:M])
 
+aggregate_neighbors(m::T, aggr::Symbol, M, cluster; kwargs...) where {T<:MessagePassing} =
+    pool(aggr, cluster, M)
+
 function propagate(mp::T; aggr::Symbol=:add, adjl=adjlist(mp), kwargs...) where {T<:MessagePassing}
     gi = GraphInfo(adjl)
 

--- a/src/layers/msgpass.jl
+++ b/src/layers/msgpass.jl
@@ -41,9 +41,7 @@ function propagate(mp::T; aggr::Symbol=:add, adjl=adjlist(mp), kwargs...) where 
     M = update_edge(mp; gi=gi, kwargs...)
 
     # aggregate function
-    Zygote.ignore() do
-        cluster = generate_cluster(M, gi)
-    end
+    cluster = generate_cluster(M, gi)
     M = aggregate_neighbors(mp, aggr; M=M, cluster=cluster)
 
     # update function

--- a/src/layers/msgpass.jl
+++ b/src/layers/msgpass.jl
@@ -1,4 +1,5 @@
 using Base.Threads
+using Zygote
 
 abstract type MessagePassing <: Meta end
 
@@ -45,7 +46,7 @@ function propagate(mp::T; aggr::Symbol=:add, adjl=adjlist(mp), kwargs...) where 
 
     # aggregate function
     cluster = generate_cluster(M, gi)
-    M = aggregate_neighbors(mp, aggr; M=M, cluster=cluster)
+    M = aggregate_neighbors(mp, aggr, M, cluster)
 
     # update function
     Y = update_vertex(mp; M=M, kwargs...)

--- a/src/layers/msgpass.jl
+++ b/src/layers/msgpass.jl
@@ -41,7 +41,10 @@ function propagate(mp::T; aggr::Symbol=:add, adjl=adjlist(mp), kwargs...) where 
     M = update_edge(mp; gi=gi, kwargs...)
 
     # aggregate function
-    M = aggregate_neighbors(mp, aggr; M=M, cluster=generate_cluster(M, gi))
+    Zygote.ignore() do
+        cluster = generate_cluster(M, gi)
+    end
+    M = aggregate_neighbors(mp, aggr; M=M, cluster=cluster)
 
     # update function
     Y = update_vertex(mp; M=M, kwargs...)

--- a/src/operations/linalg.jl
+++ b/src/operations/linalg.jl
@@ -1,5 +1,6 @@
 ## Linear algebra API for adjacency matrix
-using LinearAlgebra
+
+Zygote.@nograd issymmetric
 
 function adjacency_matrix(adj::AbstractMatrix, T::DataType=eltype(adj))
     m, n = size(adj)
@@ -124,9 +125,9 @@ function normalized_laplacian(adj::AbstractMatrix, T::DataType=eltype(adj); self
 end
 
 @doc raw"""
-    scaled_laplacian(adj::AbstractMatrix[, T::DataType]) 
+    scaled_laplacian(adj::AbstractMatrix[, T::DataType])
 
-Scaled Laplacien matrix of graph `g`, 
+Scaled Laplacien matrix of graph `g`,
 defined as ``\hat{L} = \frac{2}{\lambda_{max}} L - I`` where ``L`` is the normalized Laplacian matrix.
 
 # Arguments

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -1,4 +1,4 @@
-using Flux: Dense
+using Flux: Dense, params
 
 in_channel = 3
 out_channel = 5
@@ -20,6 +20,11 @@ adj = [0. 1. 0. 1.;
         Y = gc(X)
         @test size(Y) == (out_channel, N)
 
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(gc(X)), params(gc))
+        @test true
+        
+
         gc = GCNConv(in_channel=>out_channel)
         @test size(gc.weight) == (out_channel, in_channel)
         @test size(gc.bias) == (out_channel,)
@@ -29,6 +34,14 @@ adj = [0. 1. 0. 1.;
         fg_ = gc(fg)
         @test size(feature(fg_)) == (out_channel, N)
         @test_throws AssertionError gc(X)
+
+        @test size(feature(Zygote._pullback(x -> gc(x), fg)[1])) == (out_channel, N)
+
+        gc2 = GCNConv(in_channel=>out_channel)
+
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(feature(gc(fg))), params(gc))
+        @test true
     end
 
 
@@ -45,6 +58,10 @@ adj = [0. 1. 0. 1.;
         X = rand(in_channel, N)
         Y = cc(X)
         @test size(Y) == (out_channel, N)
+        
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(cc(X)), params(cc))
+        @test true
 
         # With variable graph
         cc = ChebConv(in_channel=>out_channel, k)
@@ -59,6 +76,10 @@ adj = [0. 1. 0. 1.;
         fg_ = cc(fg)
         @test size(feature(fg_)) == (out_channel, N)
         @test_throws AssertionError cc(X)
+        
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(cc(fg)), params(cc))
+        @test true
     end
 
     @testset "GraphConv" begin
@@ -72,6 +93,11 @@ adj = [0. 1. 0. 1.;
         Y = gc(X)
         @test size(Y) == (out_channel, N)
 
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(gc(X)), params(gc))
+        @test true
+
+
         # With variable graph
         gc = GraphConv(in_channel=>out_channel)
         @test size(gc.weight1) == (out_channel, in_channel)
@@ -84,6 +110,10 @@ adj = [0. 1. 0. 1.;
         fg_ = gc(fg)
         @test size(feature(fg_)) == (out_channel, N)
         @test_throws MethodError gc(X)
+
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(gc(fg)), params(gc))
+        @test true
     end
 
     @testset "GATConv" begin
@@ -103,6 +133,11 @@ adj = [0. 1. 0. 1.;
                     @test size(Y) == (out_channel * heads, 1)
                 end
 
+                # Test that the gradient can be computed
+                Zygote.gradient(() -> sum(gat(X)), params(gat))
+                @test true
+
+
                 # With variable graph
                 gat = GATConv(in_channel=>out_channel, heads=heads, concat=concat)
                 @test size(gat.weight) == (out_channel * heads, in_channel)
@@ -119,6 +154,10 @@ adj = [0. 1. 0. 1.;
                     @test size(Y) == (out_channel * heads, 1)
                 end
                 @test_throws MethodError gat(X)
+
+                # Test that the gradient can be computed
+                Zygote.gradient(() -> sum(gat(fg)), params(gat))
+                @test true
             end
         end
     end
@@ -133,6 +172,10 @@ adj = [0. 1. 0. 1.;
         Y = ggc(X)
         @test size(Y) == (out_channel, N)
 
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(ggc(X)), params(ggc))
+        @test true
+
 
         # With variable graph
         ggc = GatedGraphConv(out_channel, num_layers)
@@ -143,6 +186,10 @@ adj = [0. 1. 0. 1.;
         fg_ = ggc(fg)
         @test size(feature(fg_)) == (out_channel, N)
         @test_throws MethodError ggc(X)
+
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(ggc(fg)), params(ggc))
+        @test true
     end
 
     @testset "EdgeConv" begin
@@ -153,6 +200,11 @@ adj = [0. 1. 0. 1.;
         Y = ec(X)
         @test size(Y) == (out_channel, N)
 
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(ec(X)), params(ec))
+        @test true
+
+
         # With variable graph
         ec = EdgeConv(Dense(2*in_channel, out_channel))
 
@@ -161,5 +213,9 @@ adj = [0. 1. 0. 1.;
         fg_ = ec(fg)
         @test size(feature(fg_)) == (out_channel, N)
         @test_throws MethodError ec(X)
+
+        # Test that the gradient can be computed
+        Zygote.gradient(() -> sum(ec(fg)), params(ec))
+        @test true
     end
 end


### PR DESCRIPTION
I wrote some tests to show #54. The issue is actually on every message-passing layer.

A good way to start would be to write a custom Zygote adjoint for [`generate_cluster`](https://github.com/ilancoulon/GeometricFlux.jl/blob/61d497d061f19e9b511e692f9d379277627997cd/src/layers/meta.jl#L57) since this function mutates an array and Zygote does not support it.
