### PR TITLE
Fixing GCN example

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -1,5 +1,8 @@
+using Zygote
+
 const AGGR2STR = Dict{Symbol,String}(:add => "∑", :sub => "-∑", :mul => "∏", :div => "1/∏",
                                      :max => "max", :min => "min", :mean => "𝔼[]")
+
 
 """
     GCNConv([graph, ]in=>out)
@@ -46,7 +49,11 @@ function (g::GCNConv)(X::AbstractMatrix{T}) where {T}
     @assert !isnothing(graph(g.graph)) "A GCNConv created without a graph must be given a FeaturedGraph as an input."
     W, b, σ = g.weight, g.bias, g.σ
     L = normalized_laplacian(g.graph, float(T); selfloop=true)
-    L = convert(typeof(X), L)
+
+    Zygote.ignore() do
+        L = convert(typeof(X), L)
+    end
+    
     σ.(W * X * L .+ b)
 end
 

--- a/src/operations/linalg.jl
+++ b/src/operations/linalg.jl
@@ -118,10 +118,10 @@ Normalized Laplacian matrix of graph `g`.
 - `T`: result element type of degree vector; default is the element type of `g` (optional).
 - `selfloop`: adding self loop while calculating the matrix (optional).
 """
-function normalized_laplacian(adj::AbstractMatrix, T::DataType=eltype(adj); selfloop::Bool=false)
+function normalized_laplacian(adj::AbstractMatrix, T::DataType=eltype(adj); selfloop::Bool=false)::AbstractMatrix{T}
     selfloop && (adj += I)
     inv_sqrtD = inv_sqrt_degree_matrix(adj, T, dir=:both)
-    T.(I - inv_sqrtD * adj * inv_sqrtD)
+    I - inv_sqrtD * adj * inv_sqrtD
 end
 
 @doc raw"""


### PR DESCRIPTION
Tackling #61 here, I had the following error trying to launch the example:
```
ERROR: LoadError: MethodError: no method matching Float32(::ForwardDiff.Dual{Nothing,Float32,1})
Closest candidates are:
  Float32(::Real, ::RoundingMode) where T<:AbstractFloat at rounding.jl:200
  Float32(::T) where T<:Number at boot.jl:715
  Float32(::Int8) at float.jl:60
  ...
Stacktrace:
 [1] (::CuArrays.var"#68#69"{Float32})(::ForwardDiff.Dual{Nothing,Float32,1}) at C:\Users\ilanc\.julia\packages\CuArrays\YFdj7\src\broadcast.jl:21
 [2] (::Zygote.var"#1161#1164"{CuArrays.var"#68#69"{Float32}})(::Float32) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\lib\broadcast.jl:175
 [3] _broadcast_getindex_evalf at .\broadcast.jl:631 [inlined]
 [4] _broadcast_getindex at .\broadcast.jl:604 [inlined]
 [5] getindex at .\broadcast.jl:564 [inlined]
 [6] copy at .\broadcast.jl:854 [inlined]
 [7] materialize(::Base.Broadcast.Broadcasted{CuArrays.CuArrayStyle{2},Nothing,Zygote.var"#1161#1164"{CuArrays.var"#68#69"{Float32}},Tuple{CuArray{Float32,2,Nothing}}}) at .\broadcast.jl:820
 [8] broadcast_forward(::Function, ::CuArray{Float32,2,Nothing}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\lib\broadcast.jl:181
 [9] adjoint at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\lib\broadcast.jl:197 [inlined]
 [10] _pullback at C:\Users\ilanc\.julia\packages\ZygoteRules\6nssF\src\adjoint.jl:47 [inlined]
 [11] adjoint at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\lib\lib.jl:179 [inlined]
 [12] _pullback at C:\Users\ilanc\.julia\packages\ZygoteRules\6nssF\src\adjoint.jl:47 [inlined]
 [13] broadcasted at .\broadcast.jl:1232 [inlined]
 [14] _pullback(::Zygote.Context, ::typeof(Base.Broadcast.broadcasted), ::Type{Float32}, ::CuArray{Float32,2,Nothing}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
 [15] #normalized_laplacian#79 at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\src\operations\linalg.jl:124 [inlined]
 [16] _pullback(::Zygote.Context, ::GeometricFlux.var"##normalized_laplacian#79", ::Bool, ::typeof(normalized_laplacian), ::CuArray{Float32,2,Nothing}, ::Type{Float32}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0 (repeats 2 times)
 [17] #normalized_laplacian#87 at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\src\graph\featuredgraphs.jl:68 [inlined]
 [18] _pullback(::Zygote.Context, ::GeometricFlux.var"##normalized_laplacian#87", ::Bool, ::typeof(normalized_laplacian), ::FeaturedGraph{CuArray{Float32,2,Nothing},Nothing}, ::Type{Float32}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0 (repeats 2 times)
 [19] GCNConv at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\src\layers\conv.jl:48 [inlined]
 [20] _pullback(::Zygote.Context, ::GCNConv{Float32,typeof(relu),FeaturedGraph{CuArray{Float32,2,Nothing},Nothing}}, ::CuArray{Float32,2,Nothing}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
 [21] applychain at C:\Users\ilanc\.julia\packages\Flux\Fj3bt\src\layers\basic.jl:36 [inlined]
 [22] _pullback(::Zygote.Context, ::typeof(Flux.applychain), ::Tuple{GCNConv{Float32,typeof(relu),FeaturedGraph{CuArray{Float32,2,Nothing},Nothing}},Dropout{Float64,Colon},GCNConv{Float32,typeof(identity),FeaturedGraph{CuArray{Float32,2,Nothing},Nothing}},typeof(softmax)}, ::CuArray{Float32,2,Nothing}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
 [23] Chain at C:\Users\ilanc\.julia\packages\Flux\Fj3bt\src\layers\basic.jl:38 [inlined]
 [24] _pullback(::Zygote.Context, ::Chain{Tuple{GCNConv{Float32,typeof(relu),FeaturedGraph{CuArray{Float32,2,Nothing},Nothing}},Dropout{Float64,Colon},GCNConv{Float32,typeof(identity),FeaturedGraph{CuArray{Float32,2,Nothing},Nothing}},typeof(softmax)}}, ::CuArray{Float32,2,Nothing}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
 [25] loss at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\examples\gcn.jl:34 [inlined]
 [26] _pullback(::Zygote.Context, ::typeof(loss), ::CuArray{Float32,2,Nothing}, ::CuArray{Float32,2,Nothing}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
 [27] adjoint at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\lib\lib.jl:179 [inlined]
 [28] _pullback at C:\Users\ilanc\.julia\packages\ZygoteRules\6nssF\src\adjoint.jl:47 [inlined]
 [29] #17 at C:\Users\ilanc\.julia\packages\Flux\Fj3bt\src\optimise\train.jl:89 [inlined]
 [30] _pullback(::Zygote.Context, ::Flux.Optimise.var"#17#25"{typeof(loss),Tuple{CuArray{Float32,2,Nothing},CuArray{Float32,2,Nothing}}}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
 [31] pullback(::Function, ::Zygote.Params) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface.jl:172
 [32] gradient(::Function, ::Zygote.Params) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface.jl:53
 [33] macro expansion at C:\Users\ilanc\.julia\packages\Flux\Fj3bt\src\optimise\train.jl:88 [inlined]
 [34] macro expansion at C:\Users\ilanc\.julia\packages\Juno\tLMZd\src\progress.jl:134 [inlined]
 [35] train!(::typeof(loss), ::Zygote.Params, ::Array{Tuple{CuArray{Float32,2,Nothing},CuArray{Float32,2,Nothing}},1}, ::ADAM; cb::Flux.var"#throttled#20"{Flux.var"#throttled#16#21"{Bool,Bool,typeof(evalcb),Int64}}) at C:\Users\ilanc\.julia\packages\Flux\Fj3bt\src\optimise\train.jl:81
 [36] top-level scope at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\examples\gcn.jl:44
 [37] include(::String) at .\client.jl:439
 [38] top-level scope at REPL[2]:1
in expression starting at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\examples\gcn.jl:43
```

The example now works with those modifications.

I think we don't need to convert matrix eltype explicitly if given as return type (messed up with Zygote). And maybe this kind of modifications should be done on other parts of the module.

