### PR TITLE
Add differentiability tests to conv layers

### DIFF
--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -20,6 +20,9 @@ adj = [0. 1. 0. 1.;
 
             Y = gc(X)
             @test size(Y) == (out_channel, N)
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(gc(X)), params(gc))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -32,6 +35,11 @@ adj = [0. 1. 0. 1.;
             fg_ = gc(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError gc(X)
+            
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(gc(fg))), params(gc))
+            @test true
         end
     end
 
@@ -50,6 +58,10 @@ adj = [0. 1. 0. 1.;
 
             Y = cc(X)
             @test size(Y) == (out_channel, N)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(cc(X)), params(cc))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -65,6 +77,10 @@ adj = [0. 1. 0. 1.;
             fg_ = cc(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError cc(X)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(cc(fg))), params(cc))
+            @test true
         end
     end
 
@@ -79,6 +95,10 @@ adj = [0. 1. 0. 1.;
             X = rand(in_channel, N)
             Y = gc(X)
             @test size(Y) == (out_channel, N)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(gc(X)), params(gc))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -93,6 +113,10 @@ adj = [0. 1. 0. 1.;
             fg_ = gc(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError gc(X)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(gc(fg)), params(gc))
+            @test true
         end
     end
 
@@ -110,6 +134,10 @@ adj = [0. 1. 0. 1.;
 
                     Y = gat(X)
                     @test size(Y) == (out_channel * heads, N)
+
+                    # Test that the gradient can be computed
+                    Zygote.gradient(() -> sum(gat(X)), params(gat))
+                    @test true
                 end
             end
 
@@ -123,6 +151,10 @@ adj = [0. 1. 0. 1.;
 
                     Y = gat(X)
                     @test size(Y) == (out_channel * heads, 1)
+
+                    # Test that the gradient can be computed
+                    Zygote.gradient(() -> sum(gat(X)), params(gat))
+                    @test true
                 end
             end
         end
@@ -141,6 +173,10 @@ adj = [0. 1. 0. 1.;
                     Y = node_feature(fg_)
                     @test size(Y) == (out_channel * heads, N)
                     @test_throws AssertionError gat(X)
+
+                    # Test that the gradient can be computed
+                    Zygote.gradient(() -> sum(node_feature(gat(fg))), params(gat))
+                    @test true
                 end
             end
 
@@ -155,6 +191,10 @@ adj = [0. 1. 0. 1.;
                     Y = node_feature(fg_)
                     @test size(Y) == (out_channel * heads, 1)
                     @test_throws AssertionError gat(X)
+
+                    # Test that the gradient can be computed
+                    Zygote.gradient(() -> sum(node_feature(gat(fg))), params(gat))
+                    @test true
                 end
             end
         end
@@ -170,6 +210,10 @@ adj = [0. 1. 0. 1.;
             X = rand(in_channel, N)
             Y = ggc(X)
             @test size(Y) == (out_channel, N)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(ggc(X)), params(ggc))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -181,6 +225,10 @@ adj = [0. 1. 0. 1.;
             fg_ = ggc(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError ggc(X)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(ggc(fg))), params(ggc))
+            @test true
         end
     end
 
@@ -192,6 +240,10 @@ adj = [0. 1. 0. 1.;
             X = rand(in_channel, N)
             Y = ec(X)
             @test size(Y) == (out_channel, N)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(ec(X)), params(ec))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -202,6 +254,10 @@ adj = [0. 1. 0. 1.;
             fg_ = ec(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError ec(X)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(ec(fg))), params(ec))
+            @test true
         end
     end
 end

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -115,7 +115,7 @@ adj = [0. 1. 0. 1.;
             @test_throws AssertionError gc(X)
 
             # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(gc(fg)), params(gc))
+            Zygote.gradient(() -> sum(node_feature(gc(fg))), params(gc))
             @test true
         end
     end


### PR DESCRIPTION
Those tests can show if the conv layers are differentiable or not. For now, it seems they're not -> the tests fail.

The main error of the tests is in the last message of #54 , rewritten here:
```
layer without graph: Error During Test at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\test\layers\conv.jl:249
  Got exception outside of a @test
  Mutating arrays is not supported
  Stacktrace:
   [1] error(::String) at .\error.jl:33
   [2] (::Zygote.var"#463#464")(::Nothing) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\lib\array.jl:71
   [3] (::Zygote.var"#1019#back#465"{Zygote.var"#463#464"})(::Nothing) at C:\Users\ilanc\.julia\packages\ZygoteRules\6nssF\src\adjoint.jl:49
   [4] update_batch_vertex at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\src\layers\msgpass.jl:47 [inlined]
   [5] (::typeof(∂(update_batch_vertex)))(::FillArrays.Fill{Float32,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
   [6] propagate at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\src\layers\msgpass.jl:70 [inlined]
   [7] (::typeof(∂(propagate)))(::Nothing) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
   [8] EdgeConv at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\src\layers\conv.jl:438 [inlined]
   [9] (::typeof(∂(λ)))(::Nothing) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
   [10] #34 at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\test\layers\conv.jl:259 [inlined]
   [11] (::typeof(∂(λ)))(::Float32) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface2.jl:0
   [12] (::Zygote.var"#50#51"{Params,Zygote.Context,typeof(∂(λ))})(::Float32) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface.jl:177
   [13] gradient(::Function, ::Params) at C:\Users\ilanc\.julia\packages\Zygote\1GXzF\src\compiler\interface.jl:54
   [14] top-level scope at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\test\layers\conv.jl:259
   [15] top-level scope at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Test\src\Test.jl:1113
   [16] top-level scope at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\test\layers\conv.jl:250
   [17] top-level scope at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Test\src\Test.jl:1113
   [18] top-level scope at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\test\layers\conv.jl:236
   [19] top-level scope at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Test\src\Test.jl:1113
   [20] top-level scope at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\test\layers\conv.jl:13
   [21] include(::String) at .\client.jl:439
   [22] macro expansion at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\test\runtests.jl:57 [inlined]
   [23] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Test\src\Test.jl:1113 [inlined]
   [24] top-level scope at C:\Users\ilanc\Dropbox\Stage-MTL\julia\GeometricFlux.jl\test\runtests.jl:56
   [25] include(::String) at .\client.jl:439
   [26] top-level scope at REPL[2]:1
   [27] eval(::Module, ::Any) at .\boot.jl:331
   [28] eval_user_input(::Any, ::REPL.REPLBackend) at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\REPL\src\REPL.jl:86
   [29] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\REPL\src\REPL.jl:118 [inlined]
```