### PR TITLE
Make message passing layers differentiable + test that it can be computed

### DIFF
--- a/src/layers/msgpass.jl
+++ b/src/layers/msgpass.jl
@@ -30,11 +30,10 @@ First argument should be message-passing layer, the rest of arguments can be `X`
 @inline function update_batch_edge(mp::T, adj, E::AbstractMatrix, X::AbstractMatrix) where {T<:MessagePassing}
     n = size(adj, 1)
     edge_idx = edge_index_table(adj)
-    
-    hcat([update_batch_edge_from_vertex(mp, i, adj[i], edge_idx, E, X) for i in 1:n]...)
+    hcat([_apply_batch_message(mp, i, adj[i], edge_idx, E, X) for i in 1:n]...)
 end
 
-@inline function update_batch_edge_from_vertex(mp::T, i, js, edge_idx, E::AbstractMatrix, X::AbstractMatrix) where {T<:MessagePassing}
+@inline function _apply_batch_message(mp::T, i, js, edge_idx, E::AbstractMatrix, X::AbstractMatrix) where {T<:MessagePassing}
     hcat([message(mp, get_feature(X, i), get_feature(X, j), get_feature(E, edge_idx[(i,j)])) for j = js]...)
 end
 

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -20,9 +20,9 @@ adj = [0. 1. 0. 1.;
 
             Y = gc(X)
             @test size(Y) == (out_channel, N)
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(gc(X)), params(gc))
-            @test true
+            
+            g = Zygote.gradient(() -> sum(gc(X)), params(gc))
+            @test length(g.grads) == 2
         end
 
         @testset "layer without graph" begin
@@ -36,10 +36,8 @@ adj = [0. 1. 0. 1.;
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError gc(X)
 
-
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(node_feature(gc(fg))), params(gc))
-            @test true
+            g = Zygote.gradient(() -> sum(node_feature(gc(fg))), params(gc))
+            @test length(g.grads) == 4
         end
     end
 
@@ -59,9 +57,8 @@ adj = [0. 1. 0. 1.;
             Y = cc(X)
             @test size(Y) == (out_channel, N)
 
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(cc(X)), params(cc))
-            @test true
+            g = Zygote.gradient(() -> sum(cc(X)), params(cc))
+            @test length(g.grads) == 3
         end
 
         @testset "layer without graph" begin
@@ -78,9 +75,8 @@ adj = [0. 1. 0. 1.;
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError cc(X)
 
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(node_feature(cc(fg))), params(cc))
-            @test true
+            g = Zygote.gradient(() -> sum(node_feature(cc(fg))), params(cc))
+            @test length(g.grads) == 4
         end
     end
 
@@ -97,8 +93,8 @@ adj = [0. 1. 0. 1.;
             @test size(Y) == (out_channel, N)
 
             # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(gc(X)), params(gc))
-            @test true
+            g = Zygote.gradient(() -> sum(gc(X)), params(gc))
+            @test length(g.grads) == 5
         end
 
         @testset "layer without graph" begin
@@ -114,9 +110,8 @@ adj = [0. 1. 0. 1.;
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError gc(X)
 
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(node_feature(gc(fg))), params(gc))
-            @test true
+            g = Zygote.gradient(() -> sum(node_feature(gc(fg))), params(gc))
+            @test length(g.grads) == 5
         end
     end
 
@@ -135,9 +130,8 @@ adj = [0. 1. 0. 1.;
                     Y = gat(X)
                     @test size(Y) == (out_channel * heads, N)
 
-                    # Test that the gradient can be computed
-                    Zygote.gradient(() -> sum(gat(X)), params(gat))
-                    @test true
+                    g = Zygote.gradient(() -> sum(gat(X)), params(gat))
+                    @test length(g.grads) == 5
                 end
             end
 
@@ -152,9 +146,8 @@ adj = [0. 1. 0. 1.;
                     Y = gat(X)
                     @test size(Y) == (out_channel * heads, 1)
 
-                    # Test that the gradient can be computed
-                    Zygote.gradient(() -> sum(gat(X)), params(gat))
-                    @test true
+                    g = Zygote.gradient(() -> sum(gat(X)), params(gat))
+                    @test length(g.grads) == 5
                 end
             end
         end
@@ -174,9 +167,8 @@ adj = [0. 1. 0. 1.;
                     @test size(Y) == (out_channel * heads, N)
                     @test_throws AssertionError gat(X)
 
-                    # Test that the gradient can be computed
-                    Zygote.gradient(() -> sum(node_feature(gat(fg))), params(gat))
-                    @test true
+                    g = Zygote.gradient(() -> sum(node_feature(gat(fg))), params(gat))
+                    @test length(g.grads) == 5
                 end
             end
 
@@ -192,9 +184,8 @@ adj = [0. 1. 0. 1.;
                     @test size(Y) == (out_channel * heads, 1)
                     @test_throws AssertionError gat(X)
 
-                    # Test that the gradient can be computed
-                    Zygote.gradient(() -> sum(node_feature(gat(fg))), params(gat))
-                    @test true
+                    g = Zygote.gradient(() -> sum(node_feature(gat(fg))), params(gat))
+                    @test length(g.grads) == 5
                 end
             end
         end
@@ -211,9 +202,8 @@ adj = [0. 1. 0. 1.;
             Y = ggc(X)
             @test size(Y) == (out_channel, N)
 
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(ggc(X)), params(ggc))
-            @test true
+            g = Zygote.gradient(() -> sum(ggc(X)), params(ggc))
+            @test length(g.grads) == 13
         end
 
         @testset "layer without graph" begin
@@ -226,9 +216,8 @@ adj = [0. 1. 0. 1.;
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError ggc(X)
 
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(node_feature(ggc(fg))), params(ggc))
-            @test true
+            g = Zygote.gradient(() -> sum(node_feature(ggc(fg))), params(ggc))
+            @test length(g.grads) == 13
         end
     end
 
@@ -241,9 +230,8 @@ adj = [0. 1. 0. 1.;
             Y = ec(X)
             @test size(Y) == (out_channel, N)
 
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(ec(X)), params(ec))
-            @test true
+            g = Zygote.gradient(() -> sum(ec(X)), params(ec))
+            @test length(g.grads) == 4
         end
 
         @testset "layer without graph" begin
@@ -255,9 +243,8 @@ adj = [0. 1. 0. 1.;
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError ec(X)
 
-            # Test that the gradient can be computed
-            Zygote.gradient(() -> sum(node_feature(ec(fg))), params(ec))
-            @test true
+            g = Zygote.gradient(() -> sum(node_feature(ec(fg))), params(ec))
+            @test length(g.grads) == 4
         end
     end
 end

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -20,6 +20,9 @@ adj = [0. 1. 0. 1.;
 
             Y = gc(X)
             @test size(Y) == (out_channel, N)
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(gc(X)), params(gc))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -32,6 +35,11 @@ adj = [0. 1. 0. 1.;
             fg_ = gc(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError gc(X)
+
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(gc(fg))), params(gc))
+            @test true
         end
     end
 
@@ -50,6 +58,10 @@ adj = [0. 1. 0. 1.;
 
             Y = cc(X)
             @test size(Y) == (out_channel, N)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(cc(X)), params(cc))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -65,6 +77,10 @@ adj = [0. 1. 0. 1.;
             fg_ = cc(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError cc(X)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(cc(fg))), params(cc))
+            @test true
         end
     end
 
@@ -79,6 +95,10 @@ adj = [0. 1. 0. 1.;
             X = rand(in_channel, N)
             Y = gc(X)
             @test size(Y) == (out_channel, N)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(gc(X)), params(gc))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -93,6 +113,10 @@ adj = [0. 1. 0. 1.;
             fg_ = gc(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError gc(X)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(gc(fg))), params(gc))
+            @test true
         end
     end
 
@@ -110,6 +134,10 @@ adj = [0. 1. 0. 1.;
 
                     Y = gat(X)
                     @test size(Y) == (out_channel * heads, N)
+
+                    # Test that the gradient can be computed
+                    Zygote.gradient(() -> sum(gat(X)), params(gat))
+                    @test true
                 end
             end
 
@@ -123,6 +151,10 @@ adj = [0. 1. 0. 1.;
 
                     Y = gat(X)
                     @test size(Y) == (out_channel * heads, 1)
+
+                    # Test that the gradient can be computed
+                    Zygote.gradient(() -> sum(gat(X)), params(gat))
+                    @test true
                 end
             end
         end
@@ -141,6 +173,10 @@ adj = [0. 1. 0. 1.;
                     Y = node_feature(fg_)
                     @test size(Y) == (out_channel * heads, N)
                     @test_throws AssertionError gat(X)
+
+                    # Test that the gradient can be computed
+                    Zygote.gradient(() -> sum(node_feature(gat(fg))), params(gat))
+                    @test true
                 end
             end
 
@@ -155,6 +191,10 @@ adj = [0. 1. 0. 1.;
                     Y = node_feature(fg_)
                     @test size(Y) == (out_channel * heads, 1)
                     @test_throws AssertionError gat(X)
+
+                    # Test that the gradient can be computed
+                    Zygote.gradient(() -> sum(node_feature(gat(fg))), params(gat))
+                    @test true
                 end
             end
         end
@@ -170,6 +210,10 @@ adj = [0. 1. 0. 1.;
             X = rand(in_channel, N)
             Y = ggc(X)
             @test size(Y) == (out_channel, N)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(ggc(X)), params(ggc))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -181,6 +225,10 @@ adj = [0. 1. 0. 1.;
             fg_ = ggc(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError ggc(X)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(ggc(fg))), params(ggc))
+            @test true
         end
     end
 
@@ -192,6 +240,10 @@ adj = [0. 1. 0. 1.;
             X = rand(in_channel, N)
             Y = ec(X)
             @test size(Y) == (out_channel, N)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(ec(X)), params(ec))
+            @test true
         end
 
         @testset "layer without graph" begin
@@ -202,6 +254,10 @@ adj = [0. 1. 0. 1.;
             fg_ = ec(fg)
             @test size(node_feature(fg_)) == (out_channel, N)
             @test_throws AssertionError ec(X)
+
+            # Test that the gradient can be computed
+            Zygote.gradient(() -> sum(node_feature(ec(fg))), params(ec))
+            @test true
         end
     end
 end


### PR DESCRIPTION
This should be considered as a duplicate of #66 but it also solves the issue it tried to show.
If I'm correct, the modifications on `msgpass.jl` make the message passing layers differentiable.

This should close #54 