### PR TITLE
cache argument triggers error

### DIFF
--- a/examples/vgae.jl
+++ b/examples/vgae.jl
@@ -26,7 +26,7 @@ adj_mat = Matrix{Float32}(adjacency_matrix(g))
 train_data = [(FeaturedGraph(adj_mat.*M, Matrix{Float32}(features)), adj_mat) for M in masks]
 
 ## Model
-model = VGAE(GCNConv(num_features=>h_dim, relu; cache=false), h_dim, z_dim, σ)
+model = VGAE(GCNConv(num_features=>h_dim, relu;), h_dim, z_dim, σ)
 encoder = model.encoder
 decoder = model.decoder
 ps = Flux.params(model)


### PR DESCRIPTION
```
ERROR: MethodError: no method matching GCNConv(::Pair{Int64,Int64}, ::typeof(relu); cache=false)
Closest candidates are:
  GCNConv(::Pair{var"#s55",var"#s54"} where var"#s54"<:Integer where var"#s55"<:Integer, ::Any; init, T, bias) at /home/alper/.julia/packages/GeometricFlux/9riS3/src/layers/conv.jl:29 got unsupported keyword argument "cache"
  GCNConv(::Pair{var"#s108",var"#s107"} where var"#s107"<:Integer where var"#s108"<:Integer) at /home/alper/.julia/packages/GeometricFlux/9riS3/src/layers/conv.jl:29 got unsupported keyword argument "cache"
Stacktrace:
 [1] kwerr(::NamedTuple{(:cache,),Tuple{Bool}}, ::Type{T} where T, ::Pair{Int64,Int64}, ::Function) at ./error.jl:157
 [2] top-level scope at REPL[28]:1
```